### PR TITLE
Fixed some link where target was top instead of _blank

### DIFF
--- a/bcrisktool/about.html
+++ b/bcrisktool/about.html
@@ -57,7 +57,7 @@
               </ul>
               <h2 id="GailModel" class="spacerBetweenSections">The Gail Model</h2>
               <p class="content">
-                The Breast Cancer Risk Assessment Tool (BCRAT) is based on a statistical model known as the Gail Model, named after <a href="https://dceg.cancer.gov/about/staff-directory/biographies/K-N/gail-mitchell">Dr. Mitchell Gail</a>, Senior Investigator
+                The Breast Cancer Risk Assessment Tool (BCRAT) is based on a statistical model known as the Gail Model, named after <a href="https://dceg.cancer.gov/about/staff-directory/biographies/K-N/gail-mitchell" target="_blank">Dr. Mitchell Gail</a>, Senior Investigator
                 in the Biostatistics Branch of the NCI Division of Cancer Epidemiology and Genetics
               </p>
               <p class="content">
@@ -102,7 +102,7 @@
                   <li class="content">Women with a history of breast cancer have risks of recurrence that depend on the type of breast cancer, its stage at diagnosis, and treatment.  A cancer doctor can provide guidance
                   on future risks for breast cancer survivors.</li>
                   <li class="content">Women with a history of DCIS have risk of invasive breast cancer that depends on type of treatment for DCIS; a cancer doctor can provide information on this risk.</li>
-                  <li class="content">Women with a history of LCIS can use the <a href="http://www.ems-trials.org/riskevaluator/">IBIS Breast Cancer Risk Evaluation Tool</a> to estimate the risk of invasive breast cancer or DCIS.  A cancer doctor
+                  <li class="content">Women with a history of LCIS can use the <a href="http://www.ems-trials.org/riskevaluator/" target="_blank">IBIS Breast Cancer Risk Evaluation Tool</a> to estimate the risk of invasive breast cancer or DCIS.  A cancer doctor
                   can also provide information on the risk.</li>
                 </ul>
                 <br>
@@ -110,13 +110,13 @@
                 <p class="boldedBodyText">Treatment with Radiation to the Chest</p>
                 <ul>
                     <li class="content">Women who had radiation for the treatment of Hodgkin lymphoma have higher than average risk of breast cancer.  These risks are discussed in the scientific manuscript Travis, L.B
-                    et al. (Journal of the National Cancer Institute 2005; 97:1428-37). <a href="https://www.ncbi.nlm.nih.gov/pubmed/16204692">[PubMed Abstract]</a></li>
+                    et al. (Journal of the National Cancer Institute 2005; 97:1428-37). <a href="https://www.ncbi.nlm.nih.gov/pubmed/16204692" target="_blank">[PubMed Abstract]</a></li>
                 </ul>
                 <br>
 
                 <p class="boldedBodyText">A Known Mutation in Either the BRCA1 or BRCA2 Gene</p>
                 <ul>
-                  <li class="content">Women with a known mutation in either the BRCA1 or BRCA2 gene can use the <a href="http://ccge.medschl.cam.ac.uk/boadicea/">BOADICEA model</a> to estimate their breast cancer risk.</li>
+                  <li class="content">Women with a known mutation in either the BRCA1 or BRCA2 gene can use the <a href="http://ccge.medschl.cam.ac.uk/boadicea/" target="_blank">BOADICEA model</a> to estimate their breast cancer risk.</li>
                 </ul>
                 <br>
 
@@ -129,25 +129,25 @@
               <p class="content">
                 The BCRAT may be updated periodically as new data or research becomes available. The algorithm was last updated in December, 2017. The current
                 version is 4.1. Source code in SAS and R may be obtained from
-                <a href="https://dceg.cancer.gov/about/organization/programs-ebp/bb/resources">https://dceg.cancer.gov/about/organization/programs-ebp/bb/resources</a>
+                <a href="https://dceg.cancer.gov/about/organization/programs-ebp/bb/resources" target="_blank">https://dceg.cancer.gov/about/organization/programs-ebp/bb/resources</a>
               </p>
               <h4 id="reference_section">References</h4>
               <p>
                 <ol class="content">
                   <li>Gail MH, Brinton LA, Byar DP, Corle DK, Green SB, Shairer C, Mulvihill JJ: Projecting individualized probabilities of developing breast cancer for white females who are being
-                  examined annually. J Natl Cancer Inst 81(24):1879-86, 1989.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/2593165?dopt=Abstract">PubMed Abstract</a>]<br><br></li>
+                  examined annually. J Natl Cancer Inst 81(24):1879-86, 1989.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/2593165?dopt=Abstract" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Costantino JP, Gail MH, Pee D, Anderson S, Redmond CK, Benichou J, Wieand HS: Validation studies for models projecting the risk of invasive and total breast cancer incidence.
-                  J Natl Cancer Inst 91(18):1541-8, 1999.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/10491430?dopt=Abstract">PubMed Abstract</a>]<br><br></li>
+                  J Natl Cancer Inst 91(18):1541-8, 1999.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/10491430?dopt=Abstract" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Gail MH, Costantino JP, Bryant J, Croyle R, Freedman L, Helzlsouer K, Vogel V: Weighing the risks and benefits of tamoxifen treatment for preventing breast cancer. J Natl
-                  Cancer Inst 91(21):1829-46, 1999.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/10547390?dopt=Abstract">PubMed Abstract</a>]<br><br></li>
+                  Cancer Inst 91(21):1829-46, 1999.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/10547390?dopt=Abstract" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Rockhill B, Spiegelman D, Byrne C, Hunter DJ, Colditz GA: Validation of the Gail et al. model of breast cancer risk prediction and implications for chemoprevention. J Natl
-                  Cancer Inst 93(5):358-66, 2001.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/11238697?dopt=Abstract">PubMed Abstract</a>]<br><br></li>
+                  Cancer Inst 93(5):358-66, 2001.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/11238697?dopt=Abstract" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Gail MH, Costantino JP, Pee D, Bondy M, Newman L, Selvan M, Anderson GL, Malone KE, Marchbanks PA, McCaskill-Stevens W, Norman SA, Simon MS, Spirtas R, Ursin G, and
-                  Bernstein L. Projecting Individualized Absolute Invasive Breast Cancer Risk in African American Women. J Natl Cancer Inst 99(23):1782-1792, 2007.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/18042936">PubMed Abstract</a>]<br><br></li>
+                  Bernstein L. Projecting Individualized Absolute Invasive Breast Cancer Risk in African American Women. J Natl Cancer Inst 99(23):1782-1792, 2007.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/18042936" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Matsuno RK, Costantino JP, Ziegler RG, Anderson GL, Li H, Pee D, Gail MH. Projecting Individualized Absolute Invasive Breast Cancer Risk in Asian and Pacific Island American
-                  Women. J Natl Cancer Inst 2011.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/21562243">PubMed Abstract</a>]<br><br></li>
+                  Women. J Natl Cancer Inst 2011.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/21562243" target="_blank">PubMed Abstract</a>]<br><br></li>
                   <li>Banegas MP, John EM, Slattery ML, Gomez SL, Yu M, LaCroix AZ, Rowan DP. Hines CL, Thompson CA, Gail MH: Projecting Individualized Absolute Invasive Breast Cancer Risk in US
-                  Hispanic Women. J Natl Cancer Inst 109(2), 2017. doi: 10.1093/jnci/djw215.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/28003316?dopt=Abstract">PubMed Abstract</a>]<br><br></li>
+                  Hispanic Women. J Natl Cancer Inst 109(2), 2017. doi: 10.1093/jnci/djw215.&nbsp;&nbsp;[<a href="https://www.ncbi.nlm.nih.gov/pubmed/28003316?dopt=Abstract" target="_blank" >PubMed Abstract</a>]<br><br></li>
                 </ol>
               </p>
             </div>

--- a/bcrisktool/index.html
+++ b/bcrisktool/index.html
@@ -95,9 +95,9 @@
         </div>
         <h4>Resources</h4>
         <ul class="list-unstyled">
-          <li><a class="index_page_link_separator" href="https://www.cancer.gov/types/breast/hp">Breast Cancer&#8212;Health Professional Version</a></li>
-          <li><a class="index_page_link_separator"  href="http://www.cancer.gov/types/breast/risk-fact-sheet">Breast Cancer Risk in American Women</a></li>
-	  <li><a class="index_page_link_separator" href="https://www.cancer.gov/about-cancer/treatment/clinical-trials/advanced-search">Find NCI-Supported Clinical Trials</a>
+          <li><a class="index_page_link_separator"  target="_blank" href="https://www.cancer.gov/types/breast/hp">Breast Cancer&#8212;Health Professional Version</a></li>
+          <li><a class="index_page_link_separator"  target="_blank" href="http://www.cancer.gov/types/breast/risk-fact-sheet">Breast Cancer Risk in American Women</a></li>
+	        <li><a class="index_page_link_separator"  target="_blank" href="https://www.cancer.gov/about-cancer/treatment/clinical-trials/advanced-search">Find NCI-Supported Clinical Trials</a>
         </ul>
       </div>
     </div>

--- a/rat-commons/html/footer.html
+++ b/rat-commons/html/footer.html
@@ -2,7 +2,7 @@
   <ul class="list-inline">
      <li><a target="_blank" href="http://www.cancer.gov/contact">Contact</a></li>
      <li>|</li>
-     <li><a target="_top"   href="https://www.cancer.gov/policies">Policies</a></li>
+     <li><a target="_blank"   href="https://www.cancer.gov/policies">Policies</a></li>
      <li>|</li>
      <li><a target="_blank" href="https://www.cancer.gov/policies/disclaimer">Disclaimer</a></li>
      <li>|</li>


### PR DESCRIPTION
An old link name (hover_fix) got used instead of the new link name.

The purpose was to fix the links in BCRAT that went to external pages and make sure that they have target="_blank"

