### PR TITLE
NCIATWP-9969 - missing nested question fix adding new flag

### DIFF
--- a/bcrisktool/client/specificRat.js
+++ b/bcrisktool/client/specificRat.js
@@ -395,16 +395,18 @@ function addInformationToResultPageIntroductionText() {
 /* Output: Boolean (true means show in results, false means hide)            */
 /******************************************************************************/
 function filterForInputParametersDisplay(element) {
-  // Check if this is the sub race/ethnicity question
-  var isSubRaceQuestion = $(element).attr('for') === 'sub_race' || 
-                          $(element).attr('data-subquestion') === 'true';
-  
-  if (isSubRaceQuestion) {
-    // Only show sub race if Hispanic or Asian is selected
+  // Sub race question: only show when Hispanic or Asian is selected
+  if ($(element).attr('for') === 'sub_race') {
     var selectedRace = $("#race").val();
     return (selectedRace === 'Hispanic' || selectedRace === 'Asian');
   }
-  
+
+  // Biopsy sub-questions: only show when biopsy answer is "Yes"
+  var elementId = $(element).attr('id');
+  if (elementId === 'biopsy_resultLabel' || elementId === 'biopsy_ahLabel') {
+    return $("input[name='biopsy']:checked").val() === '1';
+  }
+
   // Show all other questions
   return true;
 }


### PR DESCRIPTION
There was a bug that did not display the nested biopsy answers in the results after submitting the survey. This was due to a logic error that utilized the same flag that checked for the nested ethnicity answers for the hispanic and asian options.

So the biopsy answers did not show if the patient did not choose hispanic or asian as their race.

[NCIATWP-9969](https://tracker.nci.nih.gov/browse/NCIATWP-9969)