### PR TITLE
NCIATWP-10371 - Fix duplicated question row and extra print page when editing responses

### DIFF
--- a/rat-commons/js/rat.js
+++ b/rat-commons/js/rat.js
@@ -982,8 +982,12 @@ function convertQuestionAndAnswersToTableRows(formName, tableName) {
 
 	var allTablesRows = undefined;
 
-	// Remove all <TR> nodes from the tree except the header
-	$(tableName + " tbody").find("tr:gt(0)").remove()
+	// Remove all data <TR> nodes, preserving any header row (a <tr> containing <th>).
+	// Structure-agnostic: works whether the header lives in <thead> (BCRAT, empty
+	// <tbody>) or as the first <tbody> row (CCRAT/MRAT). The old `tr:gt(0)` kept the
+	// first row, which left a stale data row behind on rebuild for BCRAT's thead-based
+	// table (NCIATWP-10371: duplicated 1st Q&A row after "Edit Responses").
+	$(tableName + " tbody").find("tr").not(":has(th)").remove()
 
 	// Verify that the parameters are valid
 	if ( form.length != 1 ) {


### PR DESCRIPTION
[NCIATWP-10371](https://tracker.nci.nih.gov/browse/NCIATWP-10371)

After generating results and using "Edit Responses" to change answers and recalculate, the first question and answer was duplicated in the results table and the printout spilled onto a third page. This fixes the shared results-table builder so it clears prior data rows correctly on every rebuild, which also restores the intended two-page printout.

- Fixed the results-table builder to remove all prior data rows while preserving the header row, so the first question and answer is no longer duplicated when responses are edited and recalculated.
- Resolved the three-page printout, which was caused by the duplicated row adding height; no print-layout changes were required.
- Verified the change is a no-op for the Colorectal and Melanoma tools, which share the same builder.