### PR TITLE
NCIATWP-10370 - Adjust the Breast Cancer Risk Assessment results page

### DIFF
--- a/bcrisktool/client/calculator.html
+++ b/bcrisktool/client/calculator.html
@@ -12,7 +12,7 @@
       gtag('config', 'UA-62346354-13');
     </script>
   <script src="//assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
-  <title>Breast Cancer Risk Assessment Calculator - NCI</title>
+  <title>NCI Breast Cancer Risk Assessment Tool</title>
   <meta name="description" content="Enter the required information to calculate a patient's absolute risk for developing breast cancer. Also known as The Gail Model. Created by the scientist at the National Cancer Institute and the NSABP." />
   <meta property="og:description" content="Enter the required information to calculate a patient's absolute risk for developing breast cancer. Created by the scientist at the National Cancer Institute and the NSABP." />
   <meta property="og:site_name" content="The Breast Cancer Risk Assessment Tool" />
@@ -98,12 +98,11 @@
           <img src="rat-commons/images/print-icon.gif" alt="printing the page">
         </button>
 
-        <div class="results-headline">Risk of Developing Breast Cancer</div>
-        <div class="results-subtitle">estimated by the NCI Breast Cancer Risk Assessment Tool</div>
+        <div class="results-headline">Patient risk as estimated by the NCI Breast Cancer Risk Assessment Tool</div>
 
         <!-- 5-Year Risk Section -->
         <section class="section-card" id="results_box">
-          <div class="section-title">5-Year Risk</div>
+          <div class="section-title" id="fiveYearTitle">5-Year Risk</div>
           <div class="risk-row">
             <div class="chart-col">
               <div class="chart-label">Patient Risk</div>
@@ -121,7 +120,7 @@
 
         <!-- Lifetime Risk Section -->
         <section class="section-card" id="results_box2">
-          <div class="section-title">Lifetime Risk</div>
+          <div class="section-title" id="lifetimeTitle">Lifetime Risk</div>
           <div class="risk-row">
             <div class="chart-col">
               <div class="chart-label">Patient Risk</div>
@@ -143,6 +142,9 @@
           <ul class="learn-more-list">
             <li><a href="https://www.cancer.gov/types/breast/patient/breast-prevention-pdq" target="_blank">Breast Cancer Prevention</a></li>
             <li><a href="https://www.cancer.gov/types/breast/patient/breast-screening-pdq" target="_blank">Breast Cancer Screening</a></li>
+            <li><a href="https://www.cancer.gov/about-cancer/treatment/clinical-trials/disease/breast-cancer/prevention" target="_blank">Current Clinical Trials-Breast Cancer Prevention</a></li>
+            <li><a href="https://www.cancer.gov/about-cancer/treatment/clinical-trials/disease/breast-cancer/screening" target="_blank">Current Clinical Trials-Breast Cancer Screening</a></li>
+            <li><a href="https://www.cancer.gov/about-cancer/treatment/clinical-trials/disease/breast-cancer/treatment" target="_blank">Current Clinical Trials-Breast Cancer Treatment</a></li>
           </ul>
         </div>
 

--- a/bcrisktool/client/specificRat.css
+++ b/bcrisktool/client/specificRat.css
@@ -154,6 +154,32 @@
   text-transform: none;
 }
 
+/* NCIATWP-10370 (AC5): match the race/ethnicity help text to the rest of the
+   table and single-space it. The shared rule sets an unquoted "NotoSans"
+   family that falls back to a different face on some systems; force the same
+   "Noto Sans" family the question cells use, and tighten the gap between the
+   stacked help paragraphs so they read as single-spaced. */
+#InputParameters .secondary_information {
+  font-family: "Noto Sans", sans-serif;
+  line-height: 1.4;
+  margin: 0 0 4px;
+}
+#InputParameters .secondary_information:last-child {
+  margin-bottom: 0;
+}
+
+/* NCIATWP-10370 (AC9): let the "Start A New Assessment" button scale with the
+   page instead of staying locked to a fixed 207x35 px box, so the label keeps
+   its size relationship and doesn't clip when text/zoom is enlarged. */
+#startOverButton {
+  width: auto;
+  min-width: 207px;
+  height: auto;
+  min-height: 35px;
+  padding: 8px 16px;
+  line-height: 1.3;
+}
+
 /* --- Notes & Caveats --- */
 .results-page .notes-caveats-section {
   margin-top: 24px;

--- a/bcrisktool/client/specificRat.js
+++ b/bcrisktool/client/specificRat.js
@@ -368,16 +368,22 @@ function resultsDisplay(response, textStatus, xhr) {
   var RED = "#BB0E3D";
   var BLUE = "#1f66c1";
 
-  var fiveYearPatientColor = (parseFloat(result.risk) > parseFloat(result.averageFiveRisk)) ? RED : BLUE;
-  var lifetimePatientColor = (parseFloat(result.lifetime_patient_risk) > parseFloat(result.lifetime_average_risk)) ? RED : BLUE;
+  // NCIATWP-10370: swap Average/Patient colors. Patient doughnut is teal when at or
+  // below average (red when higher); Average doughnut is blue.
+  var fiveYearPatientColor = (parseFloat(result.risk) > parseFloat(result.averageFiveRisk)) ? RED : TEAL;
+  var lifetimePatientColor = (parseFloat(result.lifetime_patient_risk) > parseFloat(result.lifetime_average_risk)) ? RED : TEAL;
+
+  // NCIATWP-10370: frame titles include the patient risk percentage.
+  $("#fiveYearTitle").text("5-Year Risk of Developing Breast Cancer: " + result.risk + "%");
+  $("#lifetimeTitle").text("Lifetime Risk of Developing Breast Cancer: " + result.lifetime_patient_risk + "%");
 
   $("#results_text1").html(result.message);
   $("#results_text2").html(result.lifetime_message);
 
   $("#pieChart1").html(createDonutSVG(result.risk, fiveYearPatientColor));
-  $("#pieChart2").html(createDonutSVG(result.averageFiveRisk, TEAL));
+  $("#pieChart2").html(createDonutSVG(result.averageFiveRisk, BLUE));
   $("#pieChart3").html(createDonutSVG(result.lifetime_patient_risk, lifetimePatientColor));
-  $("#pieChart4").html(createDonutSVG(result.lifetime_average_risk, TEAL));
+  $("#pieChart4").html(createDonutSVG(result.lifetime_average_risk, BLUE));
 
   applyShortenedQuestions();
 }


### PR DESCRIPTION
[NCIATWP-10370](https://tracker.nci.nih.gov/browse/NCIATWP-10370)

UI adjustments to the redesigned BCRAT results page: clearer titles that include the patient's risk percentage, additional Learn More links, a blue/teal color update on the doughnuts, and small font, spacing, scaling, and print-header fixes.

- Combine the headline and subtitle into a single line: "Patient risk as estimated by the NCI Breast Cancer Risk Assessment Tool"
- Show the patient's risk percentage in the 5-Year and Lifetime section titles
- Add three "Current Clinical Trials" links (Prevention, Screening, Treatment) to the Learn More list
- Update the doughnut colors so the Average risk is blue and the Patient risk is teal when at or below average (red when higher)
- Match the race/ethnicity help text to the rest of the responses table and single-space it
- Let the "Start A New Assessment" button scale with the page so its label no longer clips when text or zoom is enlarged
- Set the page title so the browser print header reads "NCI Breast Cancer Risk Assessment Tool"