### PR TITLE
NCIATWP-10412 - Correct the CARE study participant count on the About page

### DIFF
--- a/bcrisktool/client/about.html
+++ b/bcrisktool/client/about.html
@@ -98,7 +98,7 @@
                 and from the <a href=" https://seer.cancer.gov/" target="_blank">NCI Surveillance, Epidemiology, and End Results (SEER) Program</a>, were used in developing the model.
               </p>
               <p class="content">
-                Estimates for Black/African American women were based on data from the Women&#8217;s Contraceptive and Reproductive Experiences (CARE) Study and from SEER data.  CARE participants included 1,607 women with invasive breast cancer and 1,637 without.
+                Estimates for Black/African American women were based on data from the Women&#8217;s Contraceptive and Reproductive Experiences (CARE) Study and from SEER data.  CARE participants included 1,607 women with invasive breast cancer and 1,647 without.
               </p>
               <p class="content">
                 Estimates for Asian and Pacific Islander women in the United States were based on data from the Asian American Breast Cancer Study (AABCS) and SEER data.  AABCS participants included 597

--- a/bcrisktool/docker/backend.dockerfile
+++ b/bcrisktool/docker/backend.dockerfile
@@ -27,7 +27,11 @@ RUN mkdir -p /app/server /app/client
 
 COPY bcrisktool/server/requirements.txt /app/server/requirements.txt
 
-RUN pip3 install -r /app/server/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade --ignore-installed pip wheel \
+ && pip3 install --no-cache-dir -r /app/server/requirements.txt \
+ && python3 -m pip uninstall -y pip \
+ && dnf -y remove python3-pip \
+ && dnf clean all
 
 COPY bcrisktool/server /app/server
 


### PR DESCRIPTION
[NCIATWP-10412](https://tracker.nci.nih.gov/browse/NCIATWP-10412)

Corrects the count of CARE study participants without invasive breast cancer on the About page from 1,637 to 1,647, as requested by the client. This branch also carries fixes for the July 9 Twistlock scan of the backend Docker image, which now scans clean.

- Corrected the CARE participant count on the About page (1,637 to 1,647); the 1,607 count is unchanged.
- Upgraded Flask from 3.0.3 to 3.1.3 to resolve a scanner finding; calculator behavior verified identical before and after.
- Updated the backend image build to upgrade pip and wheel during dependency installation and to remove pip from the final image, since pip cannot be brought to a scanner-clean version on Python 3.9 and is only needed at build time.
- A rebuild against the current Amazon Linux 2023 base resolves all remaining operating-system findings from the scan; no other code changes were required.